### PR TITLE
Fix remote options and update path categorization

### DIFF
--- a/src/convert_ref_file_loc.py
+++ b/src/convert_ref_file_loc.py
@@ -57,7 +57,7 @@ def main(filename, outfile):
     print(f'Created: {out_filename}')
     print(f'Created: {osdf_filename}')
 
-def main_parquet(dict_reference, outfile, record_size=None, categorical_threshold=None):
+def main_parquet(dict_reference, outfile, categorical_threshold=None):
     """ Convert local file path to remote https file path in reference dictionary
     There are two remote paths:
     1. https://data.gdex.ucar.edu
@@ -104,9 +104,9 @@ def main_parquet(dict_reference, outfile, record_size=None, categorical_threshol
     out_filename_osdf = base_name + '-osdf.parq'
 
     # Write the modified dataframes to parquet files
-    if record_size is not None and categorical_threshold is not None:
-        df.refs_to_dataframe(dict_reference_https, out_filename_https, record_size=record_size, categorical_threshold=categorical_threshold)
-        df.refs_to_dataframe(dict_reference_osdf, out_filename_osdf, record_size=record_size, categorical_threshold=categorical_threshold)
+    if categorical_threshold is not None:
+        df.refs_to_dataframe(dict_reference_https, out_filename_https, categorical_threshold=categorical_threshold)
+        df.refs_to_dataframe(dict_reference_osdf, out_filename_osdf, categorical_threshold=categorical_threshold)
     else:
         df.refs_to_dataframe(dict_reference_https, out_filename_https)
         df.refs_to_dataframe(dict_reference_osdf, out_filename_osdf)

--- a/src/convert_ref_file_loc.py
+++ b/src/convert_ref_file_loc.py
@@ -57,7 +57,7 @@ def main(filename, outfile):
     print(f'Created: {out_filename}')
     print(f'Created: {osdf_filename}')
 
-def main_parquet(dict_reference, outfile):
+def main_parquet(dict_reference, outfile, record_size=None, categorical_threshold=None):
     """ Convert local file path to remote https file path in reference dictionary
     There are two remote paths:
     1. https://data.gdex.ucar.edu
@@ -104,8 +104,12 @@ def main_parquet(dict_reference, outfile):
     out_filename_osdf = base_name + '-osdf.parq'
 
     # Write the modified dataframes to parquet files
-    df.refs_to_dataframe(dict_reference_https, out_filename_https)
-    df.refs_to_dataframe(dict_reference_osdf, out_filename_osdf)
+    if record_size is not None and categorical_threshold is not None:
+        df.refs_to_dataframe(dict_reference_https, out_filename_https, record_size=record_size, categorical_threshold=categorical_threshold)
+        df.refs_to_dataframe(dict_reference_osdf, out_filename_osdf, record_size=record_size, categorical_threshold=categorical_threshold)
+    else:
+        df.refs_to_dataframe(dict_reference_https, out_filename_https)
+        df.refs_to_dataframe(dict_reference_osdf, out_filename_osdf)
 
     print(f'Created: {out_filename_https}')
     print(f'Created: {out_filename_osdf}')

--- a/src/create_kerchunk.py
+++ b/src/create_kerchunk.py
@@ -208,6 +208,13 @@ def _get_parser():
         default=[]
     )
 
+    parser.add_argument(
+        '--parquet_path_no_cat',
+        action='store_true',
+        default=False,
+        help="Disable category encoding for the path column in parquet output to avoid NaN in path column.",
+    )
+
     return parser
 
 
@@ -591,7 +598,7 @@ def calculate_parquet_record_size(refs_dict, min_size=10_000):
     return max(min_size, num_refs)
 
 
-def write_combined_kerchunk(output_directory, multi_kerchunk, regex=None, output_filename="",output_format="json", make_remote=False):
+def write_combined_kerchunk(output_directory, multi_kerchunk, regex=None, output_filename="",output_format="json", make_remote=False, parquet_path_no_cat=False):
     """Write kerchunk .json for combined kerchunk.
 
     Args:
@@ -640,12 +647,18 @@ def write_combined_kerchunk(output_directory, multi_kerchunk, regex=None, output
         # Expand templates here before writing.
         record_size = calculate_parquet_record_size(multi_kerchunk)
         print(f'Parquet record_size: {record_size} (refs: {len(multi_kerchunk.get("refs", multi_kerchunk))})')
-        df.refs_to_dataframe(multi_kerchunk, output_fname, record_size=record_size, categorical_threshold=record_size)
+        if parquet_path_no_cat :
+            df.refs_to_dataframe(multi_kerchunk, output_fname, record_size=record_size, categorical_threshold=record_size)
+        else :
+            df.refs_to_dataframe(multi_kerchunk, output_fname)
         print(f'Created: {output_fname}')
 
         if make_remote:
             import convert_ref_file_loc
-            convert_ref_file_loc.main_parquet(multi_kerchunk, output_fname.replace(file_extension,f'-remote{file_extension}'))
+            if parquet_path_no_cat :
+                convert_ref_file_loc.main_parquet(multi_kerchunk, output_fname.replace(file_extension,f'-remote{file_extension}'), record_size=record_size, categorical_threshold=record_size)
+            else :
+                convert_ref_file_loc.main_parquet(multi_kerchunk, output_fname.replace(file_extension,f'-remote{file_extension}'))
 
 
 def process_kerchunk_combine(
@@ -660,7 +673,8 @@ def process_kerchunk_combine(
     output_filename="",
     make_remote=False,
     output_format="json",
-    use_dask=True
+    use_dask=True,
+    parquet_path_no_cat=False
 ):
     """Traverse files in `directory` and create kerchunk aggregated files."""
 
@@ -768,7 +782,8 @@ def process_kerchunk_combine(
         regex,
         output_filename,
         output_format,
-        make_remote
+        make_remote,
+        parquet_path_no_cat
     )
 
 
@@ -828,7 +843,8 @@ def main():
             output_filename=args.filename,
             make_remote=args.make_remote,
             output_format=args.output_format[0],
-            use_dask=args.cluster[0].lower() != 'serial'
+            use_dask=args.cluster[0].lower() != 'serial',
+            parquet_path_no_cat=args.parquet_path_no_cat
         )
     else:
         print(f'action type "{args.action}" not recognized')

--- a/src/create_kerchunk.py
+++ b/src/create_kerchunk.py
@@ -648,7 +648,7 @@ def write_combined_kerchunk(output_directory, multi_kerchunk, regex=None, output
         record_size = calculate_parquet_record_size(multi_kerchunk)
         print(f'Parquet record_size: {record_size} (refs: {len(multi_kerchunk.get("refs", multi_kerchunk))})')
         if parquet_path_no_cat :
-            df.refs_to_dataframe(multi_kerchunk, output_fname, record_size=record_size, categorical_threshold=record_size)
+            df.refs_to_dataframe(multi_kerchunk, output_fname, categorical_threshold=record_size)
         else :
             df.refs_to_dataframe(multi_kerchunk, output_fname)
         print(f'Created: {output_fname}')
@@ -656,7 +656,7 @@ def write_combined_kerchunk(output_directory, multi_kerchunk, regex=None, output
         if make_remote:
             import convert_ref_file_loc
             if parquet_path_no_cat :
-                convert_ref_file_loc.main_parquet(multi_kerchunk, output_fname.replace(file_extension,f'-remote{file_extension}'), record_size=record_size, categorical_threshold=record_size)
+                convert_ref_file_loc.main_parquet(multi_kerchunk, output_fname.replace(file_extension,f'-remote{file_extension}'), categorical_threshold=record_size)
             else :
                 convert_ref_file_loc.main_parquet(multi_kerchunk, output_fname.replace(file_extension,f'-remote{file_extension}'))
 


### PR DESCRIPTION
This pull request adds support for disabling category encoding for the `path` column in Parquet outputs, addressing issues with NaN values in certain cases. The change introduces a new command-line flag and propagates this option through relevant functions to ensure consistent handling during Parquet file creation.

**Support for disabling category encoding in Parquet outputs:**

* Added a `--parquet_path_no_cat` command-line argument to `src/create_kerchunk.py` to allow users to disable category encoding for the `path` column in Parquet outputs, preventing NaN values.
* Updated the `process_kerchunk_combine` and `write_combined_kerchunk` functions in `src/create_kerchunk.py` to accept and propagate the `parquet_path_no_cat` parameter, ensuring the new option is respected throughout the Parquet creation workflow. [[1]](diffhunk://#diff-16f3635a2961257d2996b4cf6993be8a0c3576a85605dcf31f27e4f9b91588ddL663-R677) [[2]](diffhunk://#diff-16f3635a2961257d2996b4cf6993be8a0c3576a85605dcf31f27e4f9b91588ddL594-R601) [[3]](diffhunk://#diff-16f3635a2961257d2996b4cf6993be8a0c3576a85605dcf31f27e4f9b91588ddL771-R786)
* Modified the logic in `write_combined_kerchunk` and the call to `convert_ref_file_loc.main_parquet` to pass the `categorical_threshold` argument only when category encoding is disabled, ensuring correct DataFrame creation.
* Updated the `main_parquet` function in `src/convert_ref_file_loc.py` to accept an optional `categorical_threshold` parameter and use it when provided, supporting the new encoding behavior. [[1]](diffhunk://#diff-98368bae338e50904c782a95126c4999fc1c89973d32c670b1055cf7b761bcafL60-R60) [[2]](diffhunk://#diff-98368bae338e50904c782a95126c4999fc1c89973d32c670b1055cf7b761bcafR107-R110)
* Ensured the new command-line argument is correctly passed from the main entry point in `src/create_kerchunk.py` to the processing functions.